### PR TITLE
Fix behaviour when submitting non locking pages twice

### DIFF
--- a/db/mnet.php
+++ b/db/mnet.php
@@ -31,6 +31,7 @@ $publishes = array(
         'filename'   => 'mnetlib.php',
         'methods'    => array(
             'donothing',
+            'can_view_view',
         ),
     ),
 );

--- a/lang/en/assignsubmission_mahara.php
+++ b/lang/en/assignsubmission_mahara.php
@@ -23,7 +23,7 @@
  */
 
 $string['assign_submission_mahara_name'] = 'Assign Submission Mahara services';
-$string['assign_submission_mahara_description'] = 'Mahara functions used in Mahara portfolio Assign Submission plugin.<br />Publishing this service on a Moodle site has no effect. Subscribe to this service if you want to be able to use assignments with {$a}.<br />';
+$string['assign_submission_mahara_description'] = 'Mahara functions used in Mahara portfolio Assign Submission plugin.<br />Subscribe AND publish to this service if you want to be able to use assignments with {$a}.<br />';
 $string['collectionsby'] = 'Collections by {$a}';
 $string['defaultlockpages'] = 'Default "{$a}"';
 $string['defaultlockpages_help'] = 'Default setting to use for the "{$a}" setting in new Mahara assignments.';

--- a/mnetlib.php
+++ b/mnetlib.php
@@ -26,6 +26,29 @@
  */
 
 class mnetservice_assign_submission_mahara {
+
     public function donothing() {
     }
+
+    public function can_view_view($viewid, $username, $assignment, $iscollection) {
+        global $DB;
+
+        $submissionid = $DB->get_field("assignsubmission_mahara",
+                                       "submission",
+                                        array("viewid"       => $viewid,
+                                              "assignment"   => $assignment,
+                                              "iscollection" => $iscollection));
+        if (!$submissionid) {
+            return false;
+        }
+
+        $userid = $DB->get_field("assign_submission", "userid", array("id" => $submissionid));
+
+        $context = context_module::instance($assignment);
+
+        $user = $DB->get_record("user", array("username" => $username));
+
+        return $user->id == $userid || has_any_capability(array('mod/assign:grade', 'mod/assign:viewgrades'), $context, $user);
+    }
+
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2015021004;
+$plugin->version   = 2015021005;
 $plugin->requires  = 2014051200;
 $plugin->component = 'assignsubmission_mahara';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Issue #2 describes an issue where if you have your plugin set up in a
non locking manner, and submit the same page to multiple assignments,
then only the latest link will work.

The reason for this is the Mahara generates a token in an mt parameter
that changes on every submit. The non locking behaviour allows multiple
submissions, but to do that, it submits then releases, hence generating
a new token.

This patch, along with a patch in Mahara, allows sending a lock
parameter to Mahara, and then appending the url with the moodle
assignment and the mahara view/collection. Mahara will then send a
request back to Moodle to test whether you have permission to view that
view, and if so, stores the result in the session. This allows all
submission urls to work.

For upgrade paths, as this changes the get_view_url method, no change to
existing submissions is needed.

This patch makes a requirement on either a 4 line core Moodle patch, or
a local plugin, as there are issues with subplugin MNet publishers.